### PR TITLE
Permit disable the cdn on images and static files

### DIFF
--- a/pixelcrush/pixelcrush.php
+++ b/pixelcrush/pixelcrush.php
@@ -133,7 +133,7 @@ class Pixelcrush extends Module
         }
         
         if (Tools::isSubmit('submit'.$this->name)) {
-            if (Tools::getValue('PIXELCRUSH_ENABLE_IMAGES') && Tools::getValue('PIXELCRUSH_ENABLE_STATICS') &&
+            if (Tools::getIsset('PIXELCRUSH_ENABLE_IMAGES') && Tools::getIsset('PIXELCRUSH_ENABLE_STATICS') &&
                 Tools::getValue('PIXELCRUSH_USER_ACCOUNT') && Tools::getValue('PIXELCRUSH_API_SECRET') &&
                 Tools::getValue('PIXELCRUSH_FILTERS_PREFIX')
             ) {


### PR DESCRIPTION
Using Tools::getValue to validate all the fields makes impossible to disable the option "Enable Image CDN" and "Enable Static CDN (.js / .css files)" via backoffice.

This occurs because these options, when are disabled, has the value 0 and this value is evaluated like false.

![captura de pantalla de 2017-11-02 17-40-44](https://user-images.githubusercontent.com/6089334/32338432-fac70cd4-bff4-11e7-9555-24756185a95a.png)
